### PR TITLE
feat(quotes): add accessible calendar appointment semantics

### DIFF
--- a/src/components/quotes/CalendarView.test.tsx
+++ b/src/components/quotes/CalendarView.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { createRef } from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import CalendarView from './CalendarView'
+
+const quote = {
+  id: 'quote-1',
+  physio: { id: 'physio-1', name: 'Ana Gómez' },
+  client: { id: 'client-1', name: 'Bruno Díaz' },
+  startDate: '2026-07-22T10:00:00.000Z',
+  endDate: '2026-07-22T11:00:00.000Z',
+  status: 'agendada' as const,
+}
+
+afterEach(cleanup)
+
+describe('CalendarView appointment controls', () => {
+  it('exposes a focusable native appointment button with its complete name and pointer activation origin', () => {
+    const onSelectEvent = vi.fn()
+    render(<CalendarView quotes={[quote]} onSelectEvent={onSelectEvent} />)
+
+    const appointment = screen.getByRole('button', {
+      name: /Bruno Díaz.*Ana Gómez.*22.*11:00.*12:00.*agendada/i,
+    })
+    expect((appointment as HTMLButtonElement).type).toBe('button')
+
+    appointment.focus()
+    expect(document.activeElement).toBe(appointment)
+
+    fireEvent.click(appointment)
+    expect(onSelectEvent).toHaveBeenCalledWith(quote, appointment)
+  })
+
+  it('recomputes the native appointment name from refreshed data and activates the same appointment', () => {
+    const onSelectEvent = vi.fn()
+    const { rerender } = render(<CalendarView quotes={[quote]} onSelectEvent={onSelectEvent} />)
+    const refreshedQuote = {
+      ...quote,
+      physio: { ...quote.physio, name: 'Carla Ruiz' },
+      client: { ...quote.client, name: 'Diana Pérez' },
+      startDate: '2026-07-22T12:00:00.000Z',
+      endDate: '2026-07-22T13:30:00.000Z',
+      status: 'completada' as const,
+    }
+
+    rerender(<CalendarView quotes={[refreshedQuote]} onSelectEvent={onSelectEvent} />)
+
+    const appointment = screen.getByRole('button', {
+      name: /Diana Pérez.*Carla Ruiz.*22.*01:00.*02:30.*completada/i,
+    })
+    fireEvent.click(appointment)
+
+    expect(onSelectEvent).toHaveBeenCalledWith(refreshedQuote, appointment)
+    expect(screen.queryByRole('button', { name: /Bruno Díaz/i })).toBeNull()
+  })
+
+  it('forwards the calendar heading ref to its stable, programmatically focusable heading', () => {
+    const headingRef = createRef<HTMLHeadingElement>()
+    render(<CalendarView quotes={[quote]} headingRef={headingRef} />)
+
+    const heading = screen.getByRole('heading', { name: /julio de 2026/i })
+    expect(headingRef.current).toBe(heading)
+    expect((heading as HTMLHeadingElement).tabIndex).toBe(-1)
+  })
+})

--- a/src/components/quotes/CalendarView.tsx
+++ b/src/components/quotes/CalendarView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { type Ref, useState } from 'react'
 import { FiChevronLeft, FiChevronRight } from '@/lib/icons'
 import QuoteStatusBadge from './QuoteStatusBadge'
 
@@ -17,7 +17,8 @@ interface Quote {
 
 interface CalendarViewProps {
   quotes: Quote[]
-  onSelectEvent?: (quote: Quote) => void
+  onSelectEvent?: (quote: Quote, origin: HTMLButtonElement) => void
+  headingRef?: Ref<HTMLHeadingElement>
 }
 
 function formatMonthYear(date: Date): string {
@@ -39,6 +40,16 @@ function formatTime(isoString: string): string {
   })
 }
 
+function formatAppointmentName(quote: Quote): string {
+  return [
+    quote.client.name,
+    quote.physio.name,
+    formatDayHeader(quote.startDate),
+    `${formatTime(quote.startDate)} - ${formatTime(quote.endDate)}`,
+    quote.status,
+  ].join(', ')
+}
+
 function isSameMonth(isoString: string, ref: Date): boolean {
   const d = new Date(isoString)
   return d.getFullYear() === ref.getFullYear() && d.getMonth() === ref.getMonth()
@@ -57,7 +68,7 @@ function groupByDay(quotes: Quote[]): { day: string; quotes: Quote[] }[] {
     .map(([day, quotes]) => ({ day, quotes }))
 }
 
-export default function CalendarView({ quotes, onSelectEvent }: CalendarViewProps) {
+export default function CalendarView({ quotes, onSelectEvent, headingRef }: CalendarViewProps) {
   const [month, setMonth] = useState(() => {
     const now = new Date()
     return new Date(now.getFullYear(), now.getMonth(), 1)
@@ -86,9 +97,13 @@ export default function CalendarView({ quotes, onSelectEvent }: CalendarViewProp
         >
           <FiChevronLeft size={18} />
         </button>
-        <span className="text-sm font-semibold text-neutral-800 capitalize">
+        <h2
+          ref={headingRef}
+          tabIndex={-1}
+          className="text-sm font-semibold text-neutral-800 capitalize"
+        >
           {formatMonthYear(month)}
-        </span>
+        </h2>
         <button
           type="button"
           onClick={nextMonth}
@@ -115,11 +130,14 @@ export default function CalendarView({ quotes, onSelectEvent }: CalendarViewProp
               {/* Citas del día */}
               <ul className="divide-y divide-neutral-50">
                 {dayQuotes.map(q => (
-                  <li
-                    key={q.id}
-                    onClick={() => onSelectEvent?.(q)}
-                    className="flex items-center justify-between gap-4 px-4 py-3 hover:bg-neutral-50 transition-colors cursor-pointer"
-                  >
+                  <li key={q.id}>
+                    <button
+                      id={`appointment-${q.id}`}
+                      type="button"
+                      onClick={(event) => onSelectEvent?.(q, event.currentTarget)}
+                      aria-label={formatAppointmentName(q)}
+                      className="w-full flex items-center justify-between gap-4 px-4 py-3 text-left hover:bg-neutral-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500"
+                    >
                     <div className="flex items-center gap-3 min-w-0">
                       <span className="text-xs text-neutral-400 shrink-0 tabular-nums">
                         {formatTime(q.startDate)} → {formatTime(q.endDate)}
@@ -132,6 +150,7 @@ export default function CalendarView({ quotes, onSelectEvent }: CalendarViewProp
                     <div className="shrink-0">
                       <QuoteStatusBadge status={q.status} />
                     </div>
+                    </button>
                   </li>
                 ))}
               </ul>

--- a/src/components/quotes/QuoteManager.tsx
+++ b/src/components/quotes/QuoteManager.tsx
@@ -252,7 +252,7 @@ export default function QuoteManager({ initialQuotes, physios, clients }: QuoteM
       ) : (
         <CalendarView
           quotes={filteredQuotes}
-          onSelectEvent={(quote) => {
+          onSelectEvent={(quote, _origin) => {
             handleOpenEdit(quote)
           }}
         />


### PR DESCRIPTION
Closes #8

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Replaces mouse-only appointment rows with native keyboard-operable controls.
- Provides complete accessible appointment names and visible focus treatment.
- Preserves the origin callback needed by later focus-management slices.

## Changes

| File | Change |
|------|--------|
| `src/components/quotes/CalendarView.tsx` | Adds native appointment semantics, accessible names, and focus styling. |
| `src/components/quotes/CalendarView.test.tsx` | Covers keyboard activation and accessible appointment labeling. |
| `src/components/quotes/QuoteManager.tsx` | Carries the appointment origin through the selection callback. |

## Test Plan

- [x] CalendarView: 3/3 tests passed.
- [x] QuoteManager: 11/11 tests passed.
- [x] Full Vitest suite: 44/44 tests passed.
- [x] TypeScript passed.
- [x] No Next build run, per repository policy.

## Contributor Checklist

- [x] Linked approved issue #8.
- [x] Added exactly one `type:*` label.
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` or AI attribution.
- [x] No shell scripts changed; shellcheck is not applicable.
- [x] No documentation behavior change required in this slice.

## Chain Context

| Field | Value |
|-------|-------|
| Chain | `calendar-accessibility` |
| Tracker PR | Deferred until the tracker branch differs from `develop` |
| Position | 1 of 3 |
| Base | `feat/calendar-accessibility` |
| Depends on | Approved issue #8; tracker branch baseline |
| Follow-up | PR 2: modal focus containment |
| Review budget | 108 changed lines / 400 |
| Starts at | `feat/calendar-accessibility` at the `develop` baseline |
| Ends with | Keyboard-operable, screen-reader-labeled calendar appointments |

### Chain Overview

```text
develop
 └── feat/calendar-accessibility (tracker branch)
      └── 📍 PR 1: feat/calendar-accessibility-01-semantics
           └── PR 2: modal focus containment (follow-up)
                └── PR 3: focus restoration and fallback (follow-up)
```

### Scope

- Includes: appointment interaction semantics, accessible naming, focus styling, tests, and origin callback wiring.
- Excludes: modal focus containment, focus restoration, fallback focus behavior, unrelated calendar changes, and `package-lock.json`.

### Autonomy

- [x] CI is expected to pass for this PR branch.
- [x] This PR has one deliverable scope.
- [x] This PR can be rolled back without unrelated changes.
- [x] Tests cover this unit.

### Rollback Boundary

Revert commit `848308eaf57f30720ca1eab85ffd91fb61f4cf22` to remove only this semantics slice and its tests.